### PR TITLE
Propagate stream errors

### DIFF
--- a/embedding/embedding.go
+++ b/embedding/embedding.go
@@ -21,7 +21,7 @@ var INVISIBLE_RUNES_TO_UINT32 = []uint32{
 	binary.BigEndian.Uint32([]byte{0x00, 0x00, 0x00, 0x07}), // 0b000000000000000000000111
 }
 
-func Embed(embedString string, reader *bufio.Reader, writer *bufio.Writer, repeat bool) {
+func Embed(embedString string, reader *bufio.Reader, writer *bufio.Writer, repeat bool) error {
 	encoded := []rune(Encode(embedString))
 	isFirst := true
 	for {
@@ -30,29 +30,38 @@ func Embed(embedString string, reader *bufio.Reader, writer *bufio.Writer, repea
 			if err == io.EOF {
 				break
 			}
+			return err
 		}
 		if !isFirst {
 			if len(encoded) > 0 {
-				writer.WriteRune(encoded[0])
+				if _, err := writer.WriteRune(encoded[0]); err != nil {
+					return err
+				}
 				encoded = encoded[1:]
 			}
 		}
 		isFirst = false
-		writer.WriteRune(r)
+		if _, err := writer.WriteRune(r); err != nil {
+			return err
+		}
 	}
 	for len(encoded) > 0 {
-		writer.WriteRune(encoded[0])
+		if _, err := writer.WriteRune(encoded[0]); err != nil {
+			return err
+		}
 		encoded = encoded[1:]
 	}
-	writer.Flush()
+	return writer.Flush()
 }
 
-func Extract(reader *bufio.Reader, writer *bufio.Writer) string {
+func Extract(reader *bufio.Reader, writer *bufio.Writer) (string, error) {
 	b := new(bytes.Buffer)
 	noiseWriter := bufio.NewWriter(b)
-	simplenoise.DeNoiseAndWriteNoise(reader, writer, noiseWriter)
+	if err := simplenoise.DeNoiseAndWriteNoise(reader, writer, noiseWriter); err != nil {
+		return "", err
+	}
 	decoded := Decode(b.String())
-	return decoded
+	return decoded, nil
 }
 
 func Encode(text string) string {

--- a/embedding/embedding_test.go
+++ b/embedding/embedding_test.go
@@ -3,16 +3,27 @@ package embedding
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
+
+var errEmbeddingWriter = errors.New("embedding writer failed")
+
+type failingEmbeddingWriter struct{}
+
+func (failingEmbeddingWriter) Write(_ []byte) (int, error) {
+	return 0, errEmbeddingWriter
+}
 
 func TestSomething(t *testing.T) {
 	original := "Hello, World!"
 	reader := bufio.NewReader(strings.NewReader(original))
 	b := new(bytes.Buffer)
 	writer := bufio.NewWriter(b)
-	Embed(original, reader, writer, false)
+	if err := Embed(original, reader, writer, false); err != nil {
+		t.Fatal(err)
+	}
 	converted := b.String()
 	if original == converted && original != "" {
 		t.Errorf("%q == %q", original, converted)
@@ -20,9 +31,28 @@ func TestSomething(t *testing.T) {
 	reader = bufio.NewReader(bytes.NewReader(b.Bytes()))
 	b2 := new(bytes.Buffer)
 	writer = bufio.NewWriter(b2)
-	decoded := Extract(reader, writer)
+	decoded, err := Extract(reader, writer)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if original != decoded {
 		t.Errorf("Must be original = decoded (%q = %q) (decoded)", original, decoded)
+	}
+}
+
+func TestEmbedReturnsWriterError(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("Hello"))
+	writer := bufio.NewWriter(failingEmbeddingWriter{})
+	if err := Embed("hidden", reader, writer, false); !errors.Is(err, errEmbeddingWriter) {
+		t.Fatalf("Embed() error = %v, want %v", err, errEmbeddingWriter)
+	}
+}
+
+func TestExtractReturnsWriterError(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("Hello"))
+	writer := bufio.NewWriter(failingEmbeddingWriter{})
+	if _, err := Extract(reader, writer); !errors.Is(err, errEmbeddingWriter) {
+		t.Fatalf("Extract() error = %v, want %v", err, errEmbeddingWriter)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -35,7 +36,10 @@ func (p *addNoise) SetFlags(f *flag.FlagSet) {
 func (p *addNoise) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
-	simplenoise.AddRandomNoise(p.frequency, p.maxSize, reader, writer)
+	if err := simplenoise.AddRandomNoise(p.frequency, p.maxSize, reader, writer); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return subcommands.ExitFailure
+	}
 	return subcommands.ExitSuccess
 }
 
@@ -61,7 +65,10 @@ func (p *encode) SetFlags(f *flag.FlagSet) {
 func (p *encode) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
-	embedding.Embed(p.message, reader, writer, true)
+	if err := embedding.Embed(p.message, reader, writer, true); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return subcommands.ExitFailure
+	}
 	return subcommands.ExitSuccess
 }
 
@@ -82,9 +89,19 @@ func (p *decode) SetFlags(f *flag.FlagSet) {}
 func (p *decode) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
-	decoded := embedding.Extract(reader, bufio.NewWriter(ioutil.Discard))
-	writer.WriteString(decoded)
-	writer.Flush()
+	decoded, err := embedding.Extract(reader, bufio.NewWriter(ioutil.Discard))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return subcommands.ExitFailure
+	}
+	if _, err := writer.WriteString(decoded); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return subcommands.ExitFailure
+	}
+	if err := writer.Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return subcommands.ExitFailure
+	}
 	return subcommands.ExitSuccess
 }
 

--- a/simplenoise/simplenoise.go
+++ b/simplenoise/simplenoise.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kitsuyui/invisible/invisibles"
 )
 
-func AddRandomNoise(frequency float64, maxSize int, reader *bufio.Reader, writer *bufio.Writer) {
+func AddRandomNoise(frequency float64, maxSize int, reader *bufio.Reader, writer *bufio.Writer) error {
 	isFirst := true
 	for {
 		r, _, err := reader.ReadRune()
@@ -17,28 +17,33 @@ func AddRandomNoise(frequency float64, maxSize int, reader *bufio.Reader, writer
 			if err == io.EOF {
 				break
 			}
+			return err
 		}
 		if !isFirst {
 			for i := 0; i < maxSize; i++ {
 				if rand.Float64() < frequency {
 					ir := invisibles.GetInvisibleRune()
-					writer.WriteRune(ir)
+					if _, err := writer.WriteRune(ir); err != nil {
+						return err
+					}
 				}
 			}
 		}
 		isFirst = false
-		writer.WriteRune(r)
+		if _, err := writer.WriteRune(r); err != nil {
+			return err
+		}
 	}
-	writer.Flush()
+	return writer.Flush()
 }
 
-func DeNoise(reader io.Reader, writer io.Writer) {
+func DeNoise(reader io.Reader, writer io.Writer) error {
 	bufreader := bufio.NewReader(reader)
 	bufwriter := bufio.NewWriter(writer)
-	DeNoiseAndWriteNoise(bufreader, bufwriter, bufio.NewWriter(ioutil.Discard))
+	return DeNoiseAndWriteNoise(bufreader, bufwriter, bufio.NewWriter(ioutil.Discard))
 }
 
-func DeNoiseAndWriteNoise(reader io.Reader, writer io.Writer, noiseWriter io.Writer) {
+func DeNoiseAndWriteNoise(reader io.Reader, writer io.Writer, noiseWriter io.Writer) error {
 	bufReader := bufio.NewReader(reader)
 	bufWriter := bufio.NewWriter(writer)
 	noiseBufWriter := bufio.NewWriter(noiseWriter)
@@ -48,13 +53,20 @@ func DeNoiseAndWriteNoise(reader io.Reader, writer io.Writer, noiseWriter io.Wri
 			if err == io.EOF {
 				break
 			}
+			return err
 		}
 		if invisibles.IsGetInvisibleRune(r) {
-			noiseBufWriter.WriteRune(r)
+			if _, err := noiseBufWriter.WriteRune(r); err != nil {
+				return err
+			}
 		} else {
-			bufWriter.WriteRune(r)
+			if _, err := bufWriter.WriteRune(r); err != nil {
+				return err
+			}
 		}
 	}
-	bufWriter.Flush()
-	noiseBufWriter.Flush()
+	if err := bufWriter.Flush(); err != nil {
+		return err
+	}
+	return noiseBufWriter.Flush()
 }

--- a/simplenoise/simplenoise_test.go
+++ b/simplenoise/simplenoise_test.go
@@ -3,9 +3,18 @@ package simplenoise
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
+
+var errSimpleNoiseWriter = errors.New("simplenoise writer failed")
+
+type failingSimpleNoiseWriter struct{}
+
+func (failingSimpleNoiseWriter) Write(_ []byte) (int, error) {
+	return 0, errSimpleNoiseWriter
+}
 
 func TestAddRandomNoiseAndDeNoise(t *testing.T) {
 	AddRandomNoiseAndDeNoiseIsReversive(t, 1.0, 1, "Hello, Noise!")
@@ -19,7 +28,9 @@ func AddRandomNoiseAndDeNoiseIsReversive(t *testing.T, frequency float64, maxSiz
 	reader := bufio.NewReader(strings.NewReader(original))
 	b := new(bytes.Buffer)
 	writer := bufio.NewWriter(b)
-	AddRandomNoise(frequency, maxSize, reader, writer)
+	if err := AddRandomNoise(frequency, maxSize, reader, writer); err != nil {
+		t.Fatal(err)
+	}
 	converted := b.String()
 	if original == converted && original != "" {
 		t.Errorf("%q == %q", original, converted)
@@ -27,9 +38,25 @@ func AddRandomNoiseAndDeNoiseIsReversive(t *testing.T, frequency float64, maxSiz
 	reader = bufio.NewReader(bytes.NewReader(b.Bytes()))
 	b2 := new(bytes.Buffer)
 	writer = bufio.NewWriter(b2)
-	DeNoise(reader, writer)
+	if err := DeNoise(reader, writer); err != nil {
+		t.Fatal(err)
+	}
 	recovered := b2.String()
 	if original != recovered {
 		t.Errorf("%q != %q", original, recovered)
+	}
+}
+
+func TestAddRandomNoiseReturnsWriterError(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("Hello"))
+	writer := bufio.NewWriter(failingSimpleNoiseWriter{})
+	if err := AddRandomNoise(0, 0, reader, writer); !errors.Is(err, errSimpleNoiseWriter) {
+		t.Fatalf("AddRandomNoise() error = %v, want %v", err, errSimpleNoiseWriter)
+	}
+}
+
+func TestDeNoiseReturnsWriterError(t *testing.T) {
+	if err := DeNoise(strings.NewReader("Hello"), failingSimpleNoiseWriter{}); !errors.Is(err, errSimpleNoiseWriter) {
+		t.Fatalf("DeNoise() error = %v, want %v", err, errSimpleNoiseWriter)
 	}
 }


### PR DESCRIPTION
## Summary
- return stream read, write, and flush errors from noise and embedding helpers
- make CLI subcommands fail when stream processing fails
- add regression tests for writer error propagation

## Verification
- gofmt
- go test ./...
- git diff --check