### PR TITLE
Pin octocov workflow actions

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: setup
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.26.0
 
@@ -33,7 +33,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml


### PR DESCRIPTION
## Summary

- Pin the octocov workflow's third-party actions to full commit SHAs.
- Keep the original tag names as inline comments for review and future updates.

## Validation

- `git diff --check`
- YAML parse for `.github/workflows/octocov.yml`
- `actionlint .github/workflows/octocov.yml`
- `go get -v -t -d ./...`
- `go vet ./...`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`

## Notes

`go get -v -t -d ./...` completed successfully and reports that `-d` is deprecated/no-op in current Go versions.
