### PR TITLE
Skip unknown runes when decoding

### DIFF
--- a/embedding/embedding.go
+++ b/embedding/embedding.go
@@ -116,7 +116,11 @@ func decodeNRunesToNBytes(n int, m int, rs []rune) []byte {
 	uint32Bytes := 4
 	cut := uint32Bytes - m
 	for i, r := range rs {
-		k := uint32(invisibleRuneToCode(r))
+		code := invisibleRuneToCode(r)
+		if code < 0 {
+			continue
+		}
+		k := uint32(code)
 		shift := uint32(m * (bitsPerBytes - i - 1))
 		decodedUint |= k << shift
 	}

--- a/embedding/embedding_test.go
+++ b/embedding/embedding_test.go
@@ -69,6 +69,12 @@ func TestDecodeBroken(t *testing.T) {
 	TryDecodeBroken(t, "にいはお")
 }
 
+func TestDecodeSkipsUnknownRunes(t *testing.T) {
+	if decoded := Decode("A"); decoded != "" {
+		t.Fatalf("Decode() = %q, want empty string for unknown runes", decoded)
+	}
+}
+
 func TryDecodeBroken(t *testing.T, text string) {
 	encoded := Encode(text)
 	Decode(encoded[:len(encoded)-1])


### PR DESCRIPTION
## Summary
- Skip runes that are not part of the invisible alphabet during decode.
- Avoid converting the unknown-rune sentinel into a wrapped `uint32` value.
- Cover the direct `Decode` behavior for unknown input runes.

## Verification
- `go build ./...`
- `go vet ./...`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `gofmt -d embedding/embedding.go embedding/embedding_test.go`
- `git diff --check`