### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test
@@ -30,4 +34,3 @@ jobs:
 
       - name: test
         run: go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
-  create:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
 
 jobs:
   goreleaser:


### PR DESCRIPTION
## Summary

- Add explicit workflow token permissions to the Go test and release workflows.
- Remove the invalid `create` event tag filter from the release workflow so the workflow passes GitHub Actions linting.
- Keep the release trigger on version tag pushes.

## Verification

- `actionlint .github/workflows/*.yml`
- `git diff --check`