### PR TITLE
Pin workflow action refs to 40-character commit SHAs

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: setup
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.26.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: setup
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
 
       - name: release
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main


### PR DESCRIPTION
## Summary

Pin the six external `uses:` references flagged by the supply-chain audit to 40-character commit SHAs:

| File | Before | After |
| --- | --- | --- |
| `golang-test.yml:22` | `actions/checkout@v6` | `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `golang-test.yml:25` | `actions/setup-go@v6` | `actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6` |
| `release.yml:17` | `actions/checkout@v6` | `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `release.yml:20` | `actions/setup-go@v6` | `actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6` |
| `release.yml:24` | `goreleaser/goreleaser-action@v6` | `goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6` |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |

Each pinned SHA matches the value already in use either by `octocov.yml` in this same repository (`actions/checkout`, `actions/setup-go`) or by other kitsuyui org repos (`goreleaser/goreleaser-action`, `kitsuyui/gh-actions-workflows`). Behavior is therefore unchanged.

Renovate already extends `helpers:pinGitHubActionDigests` via `local>kitsuyui/renovate-config`, so future digest updates continue through automated PRs.

## Test plan

- [x] `git diff` confirms only the six `uses:` lines change
- [x] `actions/checkout` and `actions/setup-go` SHAs match the existing pinned references in `octocov.yml`