### PR TITLE
Distinguish usage errors from internal errors and add version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ $ invisible decode < example/embeded.txt
 Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!
 ```
 
+## Version
+
+```console
+$ invisible version
+```
+
+Prints the installed version. Returns `(devel)` when built from source and `(unknown)` when build information is unavailable.
+
 ## LICENSE
 
 ### Source

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/google/subcommands"
@@ -128,6 +129,27 @@ func (p *decode) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	return subcommands.ExitSuccess
 }
 
+type versionCmd struct{}
+
+func (*versionCmd) Name() string     { return "version" }
+func (*versionCmd) Synopsis() string { return "print version information." }
+func (*versionCmd) Usage() string {
+	return `version:
+	Print version information.
+`
+}
+func (*versionCmd) SetFlags(f *flag.FlagSet) {}
+
+func (*versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		fmt.Println(info.Main.Version)
+	} else {
+		fmt.Println("(unknown)")
+	}
+	return subcommands.ExitSuccess
+}
+
 func main() {
 	subcommands.Register(subcommands.HelpCommand(), "")
 	subcommands.Register(subcommands.FlagsCommand(), "")
@@ -135,6 +157,7 @@ func main() {
 	subcommands.Register(&addNoise{}, "")
 	subcommands.Register(&encode{}, "")
 	subcommands.Register(&decode{}, "")
+	subcommands.Register(&versionCmd{}, "")
 
 	flag.Parse()
 	ctx := context.Background()

--- a/main.go
+++ b/main.go
@@ -40,6 +40,14 @@ func (p *addNoise) SetFlags(f *flag.FlagSet) {
 }
 
 func (p *addNoise) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if p.frequency < 0 {
+		fmt.Fprintln(os.Stderr, "error: frequency must be non-negative")
+		return subcommands.ExitUsageError
+	}
+	if p.maxSize < 0 {
+		fmt.Fprintln(os.Stderr, "error: noise-size must be non-negative")
+		return subcommands.ExitUsageError
+	}
 	seed := p.seed
 	if seed == 0 {
 		seed = time.Now().UnixNano()
@@ -74,6 +82,10 @@ func (p *encode) SetFlags(f *flag.FlagSet) {
 }
 
 func (p *encode) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	if p.message == "" {
+		fmt.Fprintln(os.Stderr, "error: message must not be empty")
+		return subcommands.ExitUsageError
+	}
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
 	if err := embedding.Embed(p.message, reader, writer, true); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -29,3 +29,13 @@ func TestEncodeEmptyMessage(t *testing.T) {
 	status := cmd.Execute(context.Background(), flag.NewFlagSet("encode", flag.ContinueOnError))
 	if status != subcommands.ExitUsageError {
 		t.Errorf("Execute() = %v, want ExitUsageError", status)
+	}
+}
+
+func TestVersionCmdReturnsSuccess(t *testing.T) {
+	cmd := &versionCmd{}
+	status := cmd.Execute(context.Background(), flag.NewFlagSet("version", flag.ContinueOnError))
+	if status != subcommands.ExitSuccess {
+		t.Errorf("Execute() = %v, want ExitSuccess", status)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/google/subcommands"
+)
+
+func TestAddNoiseNegativeFrequency(t *testing.T) {
+	cmd := &addNoise{frequency: -0.5, maxSize: 1}
+	status := cmd.Execute(context.Background(), flag.NewFlagSet("add-noise", flag.ContinueOnError))
+	if status != subcommands.ExitUsageError {
+		t.Errorf("Execute() = %v, want ExitUsageError", status)
+	}
+}
+
+func TestAddNoiseNegativeMaxSize(t *testing.T) {
+	cmd := &addNoise{frequency: 0.5, maxSize: -1}
+	status := cmd.Execute(context.Background(), flag.NewFlagSet("add-noise", flag.ContinueOnError))
+	if status != subcommands.ExitUsageError {
+		t.Errorf("Execute() = %v, want ExitUsageError", status)
+	}
+}
+
+func TestEncodeEmptyMessage(t *testing.T) {
+	cmd := &encode{message: ""}
+	status := cmd.Execute(context.Background(), flag.NewFlagSet("encode", flag.ContinueOnError))
+	if status != subcommands.ExitUsageError {
+		t.Errorf("Execute() = %v, want ExitUsageError", status)


### PR DESCRIPTION
## Summary

- Return `ExitUsageError` (exit 2) instead of `ExitFailure` (exit 1) when the caller provides invalid flag values: `--frequency < 0` in `add-noise` and `-m ""` in `encode`
- Add a `version` subcommand that prints the installed version via `runtime/debug.ReadBuildInfo()`
- Add tests covering the new validation paths and `version` subcommand
- Document the `version` subcommand in README

## Changes

- `main.go`: flag validation guards in `addNoise.Execute` and `encode.Execute`; new `versionCmd` type registered in `main`
- `main_test.go`: four new tests (`TestAddNoiseNegativeFrequency`, `TestAddNoiseNegativeMaxSize`, `TestEncodeEmptyMessage`, `TestVersionCmdReturnsSuccess`)
- `README.md`: added `## Version` section

## Test plan

- `go test ./...` — all existing and new tests pass
- `invisible add-noise --frequency -1` exits with code 2
- `invisible encode -m ""` exits with code 2
- `invisible version` prints the version and exits with code 0