### PR TITLE
Remove unnecessary double-buffering in DeNoise

### DIFF
--- a/simplenoise/simplenoise.go
+++ b/simplenoise/simplenoise.go
@@ -3,7 +3,6 @@ package simplenoise
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"math/rand"
 
 	"github.com/kitsuyui/invisible/invisibles"
@@ -38,9 +37,7 @@ func AddRandomNoise(rng *rand.Rand, frequency float64, maxSize int, reader *bufi
 }
 
 func DeNoise(reader io.Reader, writer io.Writer) error {
-	bufreader := bufio.NewReader(reader)
-	bufwriter := bufio.NewWriter(writer)
-	return DeNoiseAndWriteNoise(bufreader, bufwriter, bufio.NewWriter(ioutil.Discard))
+	return DeNoiseAndWriteNoise(reader, writer, io.Discard)
 }
 
 func DeNoiseAndWriteNoise(reader io.Reader, writer io.Writer, noiseWriter io.Writer) error {

--- a/simplenoise/simplenoise_test.go
+++ b/simplenoise/simplenoise_test.go
@@ -49,15 +49,6 @@ func AddRandomNoiseAndDeNoiseIsReversive(t *testing.T, frequency float64, maxSiz
 	}
 }
 
-func TestAddRandomNoiseReturnsWriterError(t *testing.T) {
-	rng := rand.New(rand.NewSource(0))
-	reader := bufio.NewReader(strings.NewReader("Hello"))
-	writer := bufio.NewWriter(failingSimpleNoiseWriter{})
-	if err := AddRandomNoise(rng, 0, 0, reader, writer); !errors.Is(err, errSimpleNoiseWriter) {
-		t.Fatalf("AddRandomNoise() error = %v, want %v", err, errSimpleNoiseWriter)
-	}
-}
-
 func TestAddRandomNoiseIsReproducibleWithSameSeed(t *testing.T) {
 	input := "Hello, Reproducible!"
 	run := func() string {
@@ -73,6 +64,27 @@ func TestAddRandomNoiseIsReproducibleWithSameSeed(t *testing.T) {
 	first, second := run(), run()
 	if first != second {
 		t.Errorf("same seed produced different output: %q vs %q", first, second)
+	}
+}
+
+func TestAddRandomNoiseReturnsWriterError(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+	reader := bufio.NewReader(strings.NewReader("Hello"))
+	writer := bufio.NewWriter(failingSimpleNoiseWriter{})
+	if err := AddRandomNoise(rng, 0, 0, reader, writer); !errors.Is(err, errSimpleNoiseWriter) {
+		t.Fatalf("AddRandomNoise() error = %v, want %v", err, errSimpleNoiseWriter)
+	}
+}
+
+func TestDeNoiseWritesToPlainWriter(t *testing.T) {
+	// Regression: DeNoise must flush to a plain io.Writer, not just *bufio.Writer.
+	noisy := "H⁢ello" // H + INVISIBLE TIMES + ello
+	b := new(bytes.Buffer)
+	if err := DeNoise(strings.NewReader(noisy), b); err != nil {
+		t.Fatal(err)
+	}
+	if got := b.String(); got != "Hello" {
+		t.Errorf("DeNoise() = %q, want %q", got, "Hello")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the intermediate `bufio.NewWriter` wrapper inside `DeNoise` that was silently swallowing written data.
- Replace the removed `io/ioutil` import with `io.Discard`.
- Add `TestDeNoiseWritesToPlainWriter` regression test to guard against the bug recurring.

## Why

`DeNoise` previously created a `bufWriter := bufio.NewWriter(writer)` and passed it to `DeNoiseAndWriteNoise`, which then immediately wraps its argument in *another* `bufio.NewWriter`. The inner buffer was flushed correctly, but the outer `bufWriter` was never flushed, so data written by `DeNoiseAndWriteNoise` could remain stranded in `bufWriter`'s internal buffer and never reach the original `writer`.

This was silently harmless when the caller passed a `*bufio.Writer` (because the zero-copy fast path skipped an extra allocation), but caused data loss when the caller passed a plain `io.Writer` such as `*bytes.Buffer`.

The fix removes the redundant intermediate layer: `DeNoise` now passes `reader` and `writer` directly to `DeNoiseAndWriteNoise`, which handles its own buffering internally.

## Files Changed

- `simplenoise/simplenoise.go`: Simplify `DeNoise`; remove unused `io/ioutil` import; use `io.Discard`.
- `simplenoise/simplenoise_test.go`: Add `TestDeNoiseWritesToPlainWriter` regression test using a plain `*bytes.Buffer`.

## Test Coverage

`TestDeNoiseWritesToPlainWriter` passes a plain `*bytes.Buffer` (not `*bufio.Writer`) to `DeNoise` and asserts that the full de-noised content is present in the buffer after the call. This directly reproduces the previously broken scenario.

## Trade-offs

None. `DeNoiseAndWriteNoise` already buffers internally, so removing the outer layer has no performance impact.
