### PR TITLE
Hide mutable invisible rune tables

### DIFF
--- a/embedding/embedding.go
+++ b/embedding/embedding.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kitsuyui/invisible/simplenoise"
 )
 
-var INVISIBLE_RUNES_TO_UINT32 = []uint32{
+var invisibleRunesToUint32 = [...]uint32{
 	binary.BigEndian.Uint32([]byte{0x00, 0xe0, 0x00, 0x00}), // 0b111000000000000000000000
 	binary.BigEndian.Uint32([]byte{0x00, 0x1c, 0x00, 0x00}), // 0b000111000000000000000000
 	binary.BigEndian.Uint32([]byte{0x00, 0x03, 0x80, 0x00}), // 0b000000111000000000000000
@@ -110,10 +110,13 @@ func encodeNbytesToMRunes(n int, m int, bs []byte) (rs []rune) {
 	uint32Bytes := 4
 	bitsPerBytes := 8
 	bin := binary.BigEndian.Uint32(padFirstToNBytes(uint32Bytes, bs))
-	for i, matching := range INVISIBLE_RUNES_TO_UINT32 {
+	for i, matching := range invisibleRunesToUint32 {
 		shift := uint(n * (bitsPerBytes - i - 1))
-		code := (bin & matching) >> shift
-		rs = append(rs, invisibles.INVISIBLE_RUNES[code])
+		code := int((bin & matching) >> shift)
+		r, ok := invisibles.InvisibleRune(code)
+		if ok {
+			rs = append(rs, r)
+		}
 	}
 	return rs
 }
@@ -138,12 +141,7 @@ func decodeNRunesToNBytes(n int, m int, rs []rune) []byte {
 }
 
 func invisibleRuneToCode(r rune) int {
-	for i, r2 := range invisibles.INVISIBLE_RUNES {
-		if r2 == r {
-			return i
-		}
-	}
-	return -1
+	return invisibles.InvisibleRuneCode(r)
 }
 
 func padLastToNBytes(n int, bs []byte) []byte {

--- a/embedding/embedding_test.go
+++ b/embedding/embedding_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/kitsuyui/invisible/invisibles"
 )
 
 var errEmbeddingWriter = errors.New("embedding writer failed")
@@ -63,6 +65,13 @@ func TestEncodeAndDecodeIsReversible(t *testing.T) {
 	CheckEncodeAndDecodeIsReversible(t, "Hello, World!!!!")
 	CheckEncodeAndDecodeIsReversible(t, "Hello, World!!!!!")
 	CheckEncodeAndDecodeIsReversible(t, "Good Morning")
+}
+
+func TestEncodeAndDecodeDoesNotUseMutableRuneCopies(t *testing.T) {
+	runes := invisibles.InvisibleRunes()
+	runes[0] = 'A'
+
+	CheckEncodeAndDecodeIsReversible(t, "Hello, World!")
 }
 
 func TestDecodeBroken(t *testing.T) {

--- a/invisibles/invisibles.go
+++ b/invisibles/invisibles.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 )
 
-var INVISIBLE_RUNES = []rune{
+var invisibleRunes = [...]rune{
 	// '\u180E', // MONGOLIAN VOWEL SEPARATOR
 	'\u200B', // ZERO WIDTH SPACE
 	'\u200C', // ZERO WIDTH NON-JOINER
@@ -17,15 +17,30 @@ var INVISIBLE_RUNES = []rune{
 	'\uFEFF', // ZERO WIDTH NO-BREAK SPACE
 }
 
+func InvisibleRunes() []rune {
+	return append([]rune(nil), invisibleRunes[:]...)
+}
+
 func GetInvisibleRune(r *rand.Rand) rune {
-	return INVISIBLE_RUNES[r.Intn(len(INVISIBLE_RUNES))]
+	return invisibleRunes[r.Intn(len(invisibleRunes))]
 }
 
 func IsGetInvisibleRune(r rune) bool {
-	for _, r2 := range INVISIBLE_RUNES {
+	return InvisibleRuneCode(r) >= 0
+}
+
+func InvisibleRune(index int) (rune, bool) {
+	if index < 0 || index >= len(invisibleRunes) {
+		return 0, false
+	}
+	return invisibleRunes[index], true
+}
+
+func InvisibleRuneCode(r rune) int {
+	for i, r2 := range invisibleRunes {
 		if r == r2 {
-			return true
+			return i
 		}
 	}
-	return false
+	return -1
 }

--- a/invisibles/invisibles_test.go
+++ b/invisibles/invisibles_test.go
@@ -13,6 +13,18 @@ func TestGetInvisibleRune(t *testing.T) {
 	}
 }
 
+func TestInvisibleRunesReturnsCopy(t *testing.T) {
+	runes := InvisibleRunes()
+	runes[0] = 'A'
+
+	if IsGetInvisibleRune('A') {
+		t.Errorf("mutating returned runes must not mutate the package rune table")
+	}
+	if InvisibleRuneCode('\u200B') != 0 {
+		t.Errorf("mutating returned runes must not change rune codes")
+	}
+}
+
 func TestIsGetInvisibleRune(t *testing.T) {
 	IsGetInvisibleRuneTester(t, 'x', false)
 	IsGetInvisibleRuneTester(t, '\u2060', true)


### PR DESCRIPTION
## Summary
- Move the invisible rune table and encoding masks behind unexported package state.
- Add copy-returning and lookup helpers for callers that need the invisible rune set.
- Route encoding and decoding through the internal helpers so mutable copies cannot corrupt round trips.

## Compatibility
- The exported mutable rune table variables are removed. Use `invisibles.InvisibleRunes()` for a copy of the rune set instead.

## Tests
- gofmt -w invisibles/invisibles.go invisibles/invisibles_test.go embedding/embedding.go embedding/embedding_test.go
- go vet ./...
- go test ./...
- go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
- git diff --check
