### PR TITLE
Add --seed flag to add-noise for reproducible output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ $ invisible add-noise < example/plain.txt > example/noised.txt
 
 It looks normal. But the size is grown from 446 bytes to 1070 bytes by noise.
 
+> **Note**: `add-noise` output is non-deterministic — the invisible characters inserted vary on each run.
+> Use `--seed <N>` to get reproducible output (e.g. `--seed 42`). `encode` and `decode` are always deterministic.
+
 ```
 L⁡o​rem⁣ ⁢ip​sum ⁡d​o﻿lor⁡ ⁠sit⁡ a​met⁣,﻿ ⁠c‌ons⁠ect﻿et⁢ur⁠ ⁣a⁤di⁡p⁣isci‌n‌g e‌li⁢t,‌ ⁢se​d d⁡o‌ e​i⁡u⁠smo⁢d⁡ ​t⁠em⁡p﻿o​r i﻿n⁠cididu‌n⁡t ⁢u⁡t labo⁠re ​e⁡t​ ‌dolo⁣re​ mag‌n⁡a⁠ al⁣i​qua﻿.⁡ ⁤Ut en​im ad⁤ ‌mi﻿nim ⁡v⁢e⁣ni‌am, qui⁤s ⁢n⁡os⁣trud‌ ⁢e⁣xe‌rc⁠it﻿ati⁣on ‌u⁢l‌l⁢a​mc⁠o⁠ laboris n​i⁤si⁡ ​ut⁠ ⁢a⁠liq‌u​i⁣p e‌x e⁠a⁡ c‌o﻿mmo⁠do⁤ c﻿on⁤s⁣e⁠q⁡uat⁠. Duis aute iru⁠r⁤e ⁤d‌o﻿lor ⁤i⁣n⁢ ⁡r⁠e​pr​eh⁡e﻿nd⁤e⁠rit⁣ i⁣n⁣ vo⁡l⁣uptate⁠ v‌el⁣it ​e⁢s⁡s⁡e⁠ ⁠cil⁢l‌u​m dol​ore⁢ ​e⁢u ⁠f​u⁤g﻿i​a⁢t‌ ⁠n⁠ulla par⁣i﻿a﻿t​u⁠r​. ‌Except‌e​ur⁢ ⁤sin​t⁠ ﻿o﻿ccaecat cu​pid⁢a⁠tat ⁤n⁡o⁣n⁤ ⁠proide‌nt, ​sunt⁤ ⁡i‌n﻿ c﻿u⁡lp⁤a ⁢qui‌ off​i﻿c⁢i‌a dese​ru﻿n​t ‌mo‌l⁢li⁡t⁣ ​a⁢ni⁤m⁣ ​id ⁡est ﻿l⁤abo⁡r​u⁢m.
 

--- a/invisibles/invisibles.go
+++ b/invisibles/invisibles.go
@@ -2,7 +2,6 @@ package invisibles
 
 import (
 	"math/rand"
-	"time"
 )
 
 var INVISIBLE_RUNES = []rune{
@@ -18,13 +17,8 @@ var INVISIBLE_RUNES = []rune{
 	'\uFEFF', // ZERO WIDTH NO-BREAK SPACE
 }
 
-func init() {
-	seed := time.Now().UnixNano()
-	rand.Seed(seed)
-}
-
-func GetInvisibleRune() rune {
-	return INVISIBLE_RUNES[rand.Intn(len(INVISIBLE_RUNES))]
+func GetInvisibleRune(r *rand.Rand) rune {
+	return INVISIBLE_RUNES[r.Intn(len(INVISIBLE_RUNES))]
 }
 
 func IsGetInvisibleRune(r rune) bool {

--- a/invisibles/invisibles_test.go
+++ b/invisibles/invisibles_test.go
@@ -1,9 +1,16 @@
 package invisibles
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
 
 func TestGetInvisibleRune(t *testing.T) {
-	GetInvisibleRune()
+	rng := rand.New(rand.NewSource(1))
+	r := GetInvisibleRune(rng)
+	if !IsGetInvisibleRune(r) {
+		t.Errorf("GetInvisibleRune() = %#U, want an invisible rune", r)
+	}
 }
 
 func TestIsGetInvisibleRune(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,9 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/google/subcommands"
 	"github.com/kitsuyui/invisible/embedding"
@@ -16,6 +18,7 @@ import (
 type addNoise struct {
 	frequency float64
 	maxSize   int
+	seed      int64
 }
 
 func (*addNoise) Name() string     { return "add-noise" }
@@ -23,6 +26,8 @@ func (*addNoise) Synopsis() string { return "read from stdin and write to stdout
 func (*addNoise) Usage() string {
 	return `add-noise:
 	Read from stdin and write to stdout with noise.
+	Output varies on each run (non-deterministic) unless --seed is specified.
+	Use --seed <N> for reproducible output. encode/decode are always deterministic.
 `
 }
 
@@ -31,12 +36,18 @@ func (p *addNoise) SetFlags(f *flag.FlagSet) {
 	f.Float64Var(&p.frequency, "f", 0.5, "frequency for noise")
 	f.IntVar(&p.maxSize, "noise-size", 1, "max noise in once")
 	f.IntVar(&p.maxSize, "s", 1, "max noise in once")
+	f.Int64Var(&p.seed, "seed", 0, "random seed (0 = use time-based random seed, non-deterministic)")
 }
 
 func (p *addNoise) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	seed := p.seed
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+	rng := rand.New(rand.NewSource(seed))
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
-	if err := simplenoise.AddRandomNoise(p.frequency, p.maxSize, reader, writer); err != nil {
+	if err := simplenoise.AddRandomNoise(rng, p.frequency, p.maxSize, reader, writer); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return subcommands.ExitFailure
 	}

--- a/simplenoise/simplenoise.go
+++ b/simplenoise/simplenoise.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kitsuyui/invisible/invisibles"
 )
 
-func AddRandomNoise(frequency float64, maxSize int, reader *bufio.Reader, writer *bufio.Writer) error {
+func AddRandomNoise(rng *rand.Rand, frequency float64, maxSize int, reader *bufio.Reader, writer *bufio.Writer) error {
 	isFirst := true
 	for {
 		r, _, err := reader.ReadRune()
@@ -21,8 +21,8 @@ func AddRandomNoise(frequency float64, maxSize int, reader *bufio.Reader, writer
 		}
 		if !isFirst {
 			for i := 0; i < maxSize; i++ {
-				if rand.Float64() < frequency {
-					ir := invisibles.GetInvisibleRune()
+				if rng.Float64() < frequency {
+					ir := invisibles.GetInvisibleRune(rng)
 					if _, err := writer.WriteRune(ir); err != nil {
 						return err
 					}

--- a/simplenoise/simplenoise_test.go
+++ b/simplenoise/simplenoise_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"math/rand"
 	"strings"
 	"testing"
 )
@@ -25,10 +26,11 @@ func TestAddRandomNoiseAndDeNoise(t *testing.T) {
 
 func AddRandomNoiseAndDeNoiseIsReversive(t *testing.T, frequency float64, maxSize int, testText string) {
 	original := testText
+	rng := rand.New(rand.NewSource(42))
 	reader := bufio.NewReader(strings.NewReader(original))
 	b := new(bytes.Buffer)
 	writer := bufio.NewWriter(b)
-	if err := AddRandomNoise(frequency, maxSize, reader, writer); err != nil {
+	if err := AddRandomNoise(rng, frequency, maxSize, reader, writer); err != nil {
 		t.Fatal(err)
 	}
 	converted := b.String()
@@ -48,10 +50,29 @@ func AddRandomNoiseAndDeNoiseIsReversive(t *testing.T, frequency float64, maxSiz
 }
 
 func TestAddRandomNoiseReturnsWriterError(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
 	reader := bufio.NewReader(strings.NewReader("Hello"))
 	writer := bufio.NewWriter(failingSimpleNoiseWriter{})
-	if err := AddRandomNoise(0, 0, reader, writer); !errors.Is(err, errSimpleNoiseWriter) {
+	if err := AddRandomNoise(rng, 0, 0, reader, writer); !errors.Is(err, errSimpleNoiseWriter) {
 		t.Fatalf("AddRandomNoise() error = %v, want %v", err, errSimpleNoiseWriter)
+	}
+}
+
+func TestAddRandomNoiseIsReproducibleWithSameSeed(t *testing.T) {
+	input := "Hello, Reproducible!"
+	run := func() string {
+		rng := rand.New(rand.NewSource(12345))
+		reader := bufio.NewReader(strings.NewReader(input))
+		b := new(bytes.Buffer)
+		writer := bufio.NewWriter(b)
+		if err := AddRandomNoise(rng, 1.0, 2, reader, writer); err != nil {
+			t.Fatal(err)
+		}
+		return b.String()
+	}
+	first, second := run(), run()
+	if first != second {
+		t.Errorf("same seed produced different output: %q vs %q", first, second)
 	}
 }
 


### PR DESCRIPTION
## Why

`add-noise` used a time-based global random seed set in `init()`, making output non-deterministic on every run. There was no `--seed` flag to reproduce a specific output, and neither the README nor `--help` text documented this behaviour. Meanwhile `encode` and `decode` are deterministic, but that distinction was also undocumented.

## What

- Add `--seed int64` flag to `add-noise` (default `0` = use time-based seed, non-deterministic)
- Remove the `init()` global seeding in `invisibles/invisibles.go`
- Thread `*rand.Rand` explicitly through `AddRandomNoise()` → `GetInvisibleRune()`, eliminating global state
- Update `Usage()` help text and README to document the non-determinism contract and `--seed` usage
- Add `TestAddRandomNoiseIsReproducibleWithSameSeed` to verify same seed → same output

## How to verify

```sh
# All tests pass
go test -v -cover -race -covermode=atomic ./...

# Reproducible output with fixed seed
echo "hello" | invisible add-noise --seed 42
echo "hello" | invisible add-noise --seed 42  # identical output
```

## Trade-offs

- Seed `0` is reserved as "use time-based random" and cannot be used as an explicit deterministic seed. This is a minor limitation; users needing seed `0` can use any non-zero value.
- The `*rand.Rand` parameter is now part of the public API of `simplenoise.AddRandomNoise` and `invisibles.GetInvisibleRune`, which is a breaking change for any direct callers outside this module.
