### PR TITLE
Implement repeat behavior in Embed and add tests

### DIFF
--- a/embedding/embedding.go
+++ b/embedding/embedding.go
@@ -22,7 +22,8 @@ var INVISIBLE_RUNES_TO_UINT32 = []uint32{
 }
 
 func Embed(embedString string, reader *bufio.Reader, writer *bufio.Writer, repeat bool) error {
-	encoded := []rune(Encode(embedString))
+	originalEncoded := []rune(Encode(embedString))
+	encoded := originalEncoded
 	isFirst := true
 	for {
 		r, _, err := reader.ReadRune()
@@ -33,6 +34,9 @@ func Embed(embedString string, reader *bufio.Reader, writer *bufio.Writer, repea
 			return err
 		}
 		if !isFirst {
+			if len(encoded) == 0 && repeat {
+				encoded = originalEncoded
+			}
 			if len(encoded) > 0 {
 				if _, err := writer.WriteRune(encoded[0]); err != nil {
 					return err

--- a/embedding/embedding_test.go
+++ b/embedding/embedding_test.go
@@ -97,6 +97,56 @@ func TestInvisibleRuneToCodeFailure(t *testing.T) {
 	}
 }
 
+func TestEmbedRepeatEmbedsDifferentlyFromNoRepeat(t *testing.T) {
+	message := "Hi"
+	// Host text longer than what's needed to embed the message once.
+	// Encode("Hi") produces 8*ceil(2/3) = 8 invisible runes; host text of 200 chars
+	// ensures encoded runes would be exhausted well before the host ends.
+	hostText := strings.Repeat("Hello World! ", 20)
+
+	embed := func(rep bool) string {
+		reader := bufio.NewReader(strings.NewReader(hostText))
+		b := new(bytes.Buffer)
+		writer := bufio.NewWriter(b)
+		if err := Embed(message, reader, writer, rep); err != nil {
+			t.Fatal(err)
+		}
+		return b.String()
+	}
+
+	withRepeat := embed(true)
+	withoutRepeat := embed(false)
+
+	if withRepeat == withoutRepeat {
+		t.Error("Embed with repeat=true should produce different output than repeat=false for long host text")
+	}
+}
+
+func TestEmbedRepeatExtractRecoversMessage(t *testing.T) {
+	message := "Hi"
+	hostText := strings.Repeat("Hello World! ", 20)
+
+	reader := bufio.NewReader(strings.NewReader(hostText))
+	b := new(bytes.Buffer)
+	writer := bufio.NewWriter(b)
+	if err := Embed(message, reader, writer, true); err != nil {
+		t.Fatal(err)
+	}
+
+	reader2 := bufio.NewReader(bytes.NewReader(b.Bytes()))
+	b2 := new(bytes.Buffer)
+	writer2 := bufio.NewWriter(b2)
+	decoded, err := Extract(reader2, writer2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Extract decodes all embedded invisible characters. With repeat the decoded
+	// string will be message repeated; check that it starts with the original message.
+	if !strings.HasPrefix(decoded, message) {
+		t.Errorf("Extract after Embed(repeat=true): got %q, want prefix %q", decoded, message)
+	}
+}
+
 func TestEncodeAndDecodeWithNullBytes(t *testing.T) {
 	// Null byte at the start of a chunk (was incorrectly stripped by bytes.Trim).
 	CheckEncodeAndDecodeIsReversible(t, "\x00AB")


### PR DESCRIPTION
## Summary

The `Embed` function accepted a `repeat bool` parameter but never referenced it in the function body. When `repeat=true`, the encoded rune sequence would silently exhaust without restarting, making the parameter meaningless.

## Changes

- **`embedding/embedding.go`**: Implement `repeat` logic. When `repeat=true` and the encoded rune slice is exhausted, it resets to the original encoded sequence so the hidden message repeats throughout the host text.
- **`embedding/embedding_test.go`**: Add two tests:
  - `TestEmbedRepeatEmbedsDifferentlyFromNoRepeat`: asserts that `repeat=true` produces different output than `repeat=false` for a long host text.
  - `TestEmbedRepeatExtractRecoversMessage`: asserts that `Extract` recovers the original message after `Embed` with `repeat=true`.

## Verification

- All existing tests pass: `go test ./...`
- `go vet ./...`: no issues
- `staticcheck ./...`: 2 pre-existing warnings (`io/ioutil` deprecated in `main.go` and `simplenoise/simplenoise.go`) — unrelated to this change, out of scope.

## Trade-offs

This is a minimal surface fix. The `repeat bool` parameter contract is now implemented rather than silently ignored. The `Extract` function reads all embedded invisible characters in sequence, so after `Embed(repeat=true)` the decoded result will contain the message repeated (not just once). Callers that only need to verify the first occurrence should check for a prefix or extract up to the first message boundary.
