### PR TITLE
Fix README embedded example path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ L⁡o​rem⁣ ⁢ip​sum ⁡d​o﻿lor⁡ ⁠sit⁡ a​met⁣,﻿ ⁠c‌ons
 ## Encode
 
 ```console
-$ invisible encode -m 'Hello, World!' < example/plain.txt > example/embeded.txt
+$ invisible encode -m 'Hello, World!' < example/plain.txt > example/embedded.txt
 ```
 
 ## Encoded text
@@ -41,7 +41,7 @@ L⁠o⁠r​e⁤m⁠ ⁣i⁣p⁢s⁡u⁡m​ ⁤d﻿o⁢l⁣o⁢r‌ ​s​i⁣
 ## Decode
 
 ```console
-$ invisible decode < example/embeded.txt
+$ invisible decode < example/embedded.txt
 Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!
 ```
 


### PR DESCRIPTION
## Summary
- Correct the README encode and decode examples to use `example/embedded.txt`.
- Keep the README examples aligned with the checked-in example file and `bin/generate_examples.sh`.

## Verification
- `go test ./...`
- `go vet ./...`
- `typos .`
- `git diff --check`
- README example path check: `example/embedded.txt` exists and `example/embeded.txt` does not.

## Notes
- This is a documentation-only fix.
