### PR TITLE
docs(embedding): document Embed two-phase encoding and add trailing-block test

### DIFF
--- a/embedding/embedding.go
+++ b/embedding/embedding.go
@@ -38,6 +38,27 @@ var invisibleRunesToUint32 = [...]uint32{
 	binary.BigEndian.Uint32([]byte{0x00, 0x00, 0x00, 0x07}), // 0b000000000000000000000111
 }
 
+// Embed hides embedString in the host text from reader by interleaving
+// invisible Unicode runes into writer.
+//
+// The encoding operates in two phases depending on the relative lengths of the
+// host text and the encoded message rune sequence:
+//
+//  1. Interleave mode: while visible characters and encoded runes both remain,
+//     one invisible rune is inserted immediately before each visible character,
+//     except before the very first visible character (isFirst guard). This
+//     distributes invisible runes evenly through the host text.
+//
+//  2. Trailing-block mode: if encoded runes remain after the host text is
+//     exhausted (i.e. len([]rune(Encode(embedString))) > number of visible chars),
+//     the remaining runes are appended as a contiguous block at the end of the
+//     output. Contiguous invisible runes are more detectable by analysis tools
+//     than interleaved ones; callers should prefer host text at least as long as
+//     len([]rune(Encode(embedString))) to stay in interleave mode.
+//
+// The repeat parameter causes the encoded rune sequence to cycle back to the
+// beginning once exhausted, but only applies in interleave mode while visible
+// characters remain in the host text. It has no effect in trailing-block mode.
 func Embed(embedString string, reader *bufio.Reader, writer *bufio.Writer, repeat bool) error {
 	originalEncoded := []rune(Encode(embedString))
 	encoded := originalEncoded

--- a/embedding/embedding_test.go
+++ b/embedding/embedding_test.go
@@ -156,6 +156,47 @@ func TestEmbedRepeatExtractRecoversMessage(t *testing.T) {
 	}
 }
 
+// TestEmbedTrailingBlockMode covers the case where the host text is shorter
+// than the encoded message rune count, triggering trailing-block mode: all
+// remaining encoded runes are appended as a contiguous block after the last
+// visible character. The round-trip must still recover the original message.
+func TestEmbedTrailingBlockMode(t *testing.T) {
+	message := "AB"
+	// "x" is a single-character host: isFirst prevents any interleaved invisible
+	// rune from being inserted before it, so all encoded runes go to the trailing block.
+	hostText := "x"
+
+	reader := bufio.NewReader(strings.NewReader(hostText))
+	b := new(bytes.Buffer)
+	writer := bufio.NewWriter(b)
+	if err := Embed(message, reader, writer, false); err != nil {
+		t.Fatal(err)
+	}
+
+	embedded := b.String()
+	if embedded == hostText {
+		t.Error("Embed produced no invisible runes; trailing-block mode did not activate")
+	}
+
+	// The embedded output must start with the host text visible character.
+	embeddedRunes := []rune(embedded)
+	if embeddedRunes[0] != rune(hostText[0]) {
+		t.Errorf("first rune = %q, want %q", embeddedRunes[0], rune(hostText[0]))
+	}
+
+	// Round-trip: Extract must recover the original message.
+	reader2 := bufio.NewReader(bytes.NewReader(b.Bytes()))
+	b2 := new(bytes.Buffer)
+	writer2 := bufio.NewWriter(b2)
+	decoded, err := Extract(reader2, writer2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded != message {
+		t.Errorf("Extract after trailing-block Embed: got %q, want %q", decoded, message)
+	}
+}
+
 func TestEncodeAndDecodeWithNullBytes(t *testing.T) {
 	// Null byte at the start of a chunk (was incorrectly stripped by bytes.Trim).
 	CheckEncodeAndDecodeIsReversible(t, "\x00AB")


### PR DESCRIPTION
## Summary

Document the implicit two-phase encoding behavior in `Embed()` and add a boundary condition test.

`Embed()` operates in two phases depending on the relative lengths of the host text and the encoded message:

1. **Interleave mode**: while both visible characters and encoded runes remain, one invisible rune is inserted before each visible character (except the first). This distributes runes evenly through the host text.
2. **Trailing-block mode**: if encoded runes remain after the host text is exhausted, they are appended as a contiguous block at the end. Contiguous invisible runes are more detectable by steganography analysis tools than interleaved ones.

Previously, neither the function signature nor GoDoc described this two-state behavior, and the trailing-block code path had no test coverage.

## Changes

- `embedding/embedding.go`: add GoDoc comment to `Embed()` documenting both phases, the `isFirst` guard, and the `repeat` parameter's scope (interleave mode only)
- `embedding/embedding_test.go`: add `TestEmbedTrailingBlockMode` covering the boundary condition where host text is shorter than the encoded rune count

## Test plan

- [x] `go test ./...` passes (all existing tests + new `TestEmbedTrailingBlockMode`)
- [x] `go vet ./...` passes
- [x] `staticcheck ./embedding/...` reports 0 findings
- [x] `gofmt -l .` reports no formatting issues
