### PR TITLE
strip ANSI/VT escape sequences from decode output

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func (p *decode) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 		fmt.Fprintln(os.Stderr, err)
 		return subcommands.ExitFailure
 	}
-	if _, err := writer.WriteString(decoded); err != nil {
+	if _, err := writer.WriteString(stripANSI(decoded)); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return subcommands.ExitFailure
 	}

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,21 @@
+package main
+
+import "regexp"
+
+// ansiEscapeRe matches ANSI/VT terminal escape sequences:
+//   - CSI sequences: ESC [ ... final-byte  (cursor, color, erase commands)
+//   - OSC sequences: ESC ] ... BEL or ST   (title, clipboard injection via OSC 52)
+//   - Other two-byte sequences: ESC + single char
+var ansiEscapeRe = regexp.MustCompile(
+	`\x1b` +
+		`(?:` +
+		`\[[0-?]*[ -/]*[@-~]` + // CSI: ESC [ param-bytes intermediate-bytes final-byte
+		`|\][^\x07\x1b]*(?:\x07|\x1b\\)` + // OSC: ESC ] ... BEL|ST
+		`|[^[\]]` + // Other: ESC + one char (not [ or ])
+		`)`,
+)
+
+// stripANSI removes ANSI/VT terminal escape sequences from s.
+func stripANSI(s string) string {
+	return ansiEscapeRe.ReplaceAllString(s, "")
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,65 @@
+package main
+
+import "testing"
+
+func TestStripANSI(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text unchanged",
+			input: "hello world",
+			want:  "hello world",
+		},
+		{
+			name:  "CSI color sequence",
+			input: "\x1b[31mred\x1b[0m",
+			want:  "red",
+		},
+		{
+			name:  "CSI erase screen",
+			input: "before\x1b[2Jafter",
+			want:  "beforeafter",
+		},
+		{
+			name:  "CSI cursor hide",
+			input: "\x1b[?25l",
+			want:  "",
+		},
+		{
+			name:  "OSC terminal title",
+			input: "\x1b]0;evil title\x07",
+			want:  "",
+		},
+		{
+			name:  "OSC with ST terminator",
+			input: "\x1b]0;evil\x1b\\text",
+			want:  "text",
+		},
+		{
+			name:  "OSC 52 clipboard injection",
+			input: "\x1b]52;c;cGVybA==\x07",
+			want:  "",
+		},
+		{
+			name:  "two-byte ESC sequence",
+			input: "\x1b=",
+			want:  "",
+		},
+		{
+			name:  "mixed content",
+			input: "safe\x1b[31mcolor\x1b[0msafe",
+			want:  "safecolorsafe",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripANSI(tc.input)
+			if got != tc.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `decode` subcommand extracted the hidden message and wrote it to stdout
with no output filtering. A crafted encoded message containing ANSI/VT escape
sequences would be executed by the terminal emulator when decoded:

- CSI sequences (`\x1b[2J`, `\x1b[?25l`) — screen clear, cursor hide
- OSC sequences (`\x1b]0;...\x07`) — terminal title rewrite
- OSC 52 (`\x1b]52;c;<base64>\x07`) — clipboard injection

## Change

- Add `sanitize.go` with `stripANSI` that removes CSI, OSC, and other
  two-byte ESC sequences using a regexp.
- Apply `stripANSI(decoded)` in `decode.Execute` before writing to stdout.
- `embedding.Extract` / `embedding.Decode` are unchanged; they return raw bytes
  as before. Sanitization is applied only at the terminal output boundary.

## Test plan

- [ ] `TestStripANSI` in `sanitize_test.go` covers CSI color, erase, cursor
  hide, OSC title, OSC ST, OSC 52, two-byte ESC, and plain text.
- [ ] All existing tests continue to pass (`go test -race ./...`).
- [ ] `go vet ./...` reports no issues.