### PR TITLE
Add encoding format marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ $ invisible decode < example/embedded.txt
 Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!
 ```
 
+## Encoding format
+
+Encoded messages start with an invisible `v1` format marker. The decoder still
+accepts older markerless payloads for compatibility, and rejects payloads that
+use the reserved marker prefix with an unsupported version.
+
 ## Version
 
 ```console

--- a/embedding/embedding.go
+++ b/embedding/embedding.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/kitsuyui/invisible/invisibles"
 	"github.com/kitsuyui/invisible/simplenoise"
@@ -14,6 +16,15 @@ import (
 // maxNoiseBufBytes caps the noise buffer in Extract to guard against OOM from
 // inputs crafted with large numbers of invisible runes.
 const maxNoiseBufBytes int64 = 1 << 20 // 1 MiB
+
+const (
+	encodingFormatMarkerPrefix = string(invisibles.EncodingFormatMarkerRune) + string(invisibles.EncodingFormatMarkerRune)
+	encodingFormatMarkerV1     = encodingFormatMarkerPrefix + "\u200B"
+)
+
+// ErrUnsupportedEncodingFormat reports an encoded payload with a reserved
+// format marker prefix that this decoder does not support.
+var ErrUnsupportedEncodingFormat = errors.New("unsupported invisible encoding format")
 
 type limitedBuffer struct {
 	buf *bytes.Buffer
@@ -60,8 +71,8 @@ var invisibleRunesToUint32 = [...]uint32{
 // beginning once exhausted, but only applies in interleave mode while visible
 // characters remain in the host text. It has no effect in trailing-block mode.
 func Embed(embedString string, reader *bufio.Reader, writer *bufio.Writer, repeat bool) error {
-	originalEncoded := []rune(Encode(embedString))
-	encoded := originalEncoded
+	originalEncoded := []rune(encodeLegacy(embedString))
+	encoded := append([]rune(encodingFormatMarkerV1), originalEncoded...)
 	isFirst := true
 	for {
 		r, _, err := reader.ReadRune()
@@ -103,11 +114,14 @@ func Extract(reader *bufio.Reader, writer *bufio.Writer) (string, error) {
 	if err := simplenoise.DeNoiseAndWriteNoise(reader, writer, noiseWriter); err != nil {
 		return "", err
 	}
-	decoded := Decode(b.String())
-	return decoded, nil
+	return DecodeStrict(b.String())
 }
 
 func Encode(text string) string {
+	return encodingFormatMarkerV1 + encodeLegacy(text)
+}
+
+func encodeLegacy(text string) string {
 	var encoded []rune
 	bs := []byte(text)
 	byteSizeEncodeFrom := 3
@@ -125,6 +139,27 @@ func Encode(text string) string {
 }
 
 func Decode(noiseText string) string {
+	decoded, err := DecodeStrict(noiseText)
+	if err != nil {
+		return ""
+	}
+	return decoded
+}
+
+// DecodeStrict decodes markerless legacy payloads and v1-marked payloads.
+// Unsupported marked payloads return ErrUnsupportedEncodingFormat.
+func DecodeStrict(noiseText string) (string, error) {
+	switch {
+	case strings.HasPrefix(noiseText, encodingFormatMarkerV1):
+		return decodeLegacy(strings.TrimPrefix(noiseText, encodingFormatMarkerV1)), nil
+	case strings.HasPrefix(noiseText, encodingFormatMarkerPrefix):
+		return "", ErrUnsupportedEncodingFormat
+	default:
+		return decodeLegacy(noiseText), nil
+	}
+}
+
+func decodeLegacy(noiseText string) string {
 	var decoded []byte
 	runes := []rune(noiseText)
 	runeSizeDecodeFrom := 8

--- a/embedding/embedding_test.go
+++ b/embedding/embedding_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -67,6 +68,46 @@ func TestEncodeAndDecodeIsReversible(t *testing.T) {
 	CheckEncodeAndDecodeIsReversible(t, "Good Morning")
 }
 
+func TestEncodeAddsEncodingFormatMarker(t *testing.T) {
+	encoded := Encode("Hello, World!")
+	if !strings.HasPrefix(encoded, encodingFormatMarkerV1) {
+		t.Fatal("Encode() did not prefix the encoding format marker")
+	}
+}
+
+func TestDecodeAcceptsLegacyMarkerlessPayload(t *testing.T) {
+	encoded := encodeLegacy("Hello, World!")
+	if strings.HasPrefix(encoded, encodingFormatMarkerPrefix) {
+		t.Fatal("legacy encoded payload unexpectedly starts with the format marker prefix")
+	}
+	if decoded := Decode(encoded); decoded != "Hello, World!" {
+		t.Fatalf("Decode() = %q, want legacy payload", decoded)
+	}
+}
+
+func TestDecodeStrictRejectsUnsupportedEncodingFormat(t *testing.T) {
+	_, err := DecodeStrict(encodingFormatMarkerPrefix + "\u200C" + encodeLegacy("Hello"))
+	if !errors.Is(err, ErrUnsupportedEncodingFormat) {
+		t.Fatalf("DecodeStrict() error = %v, want %v", err, ErrUnsupportedEncodingFormat)
+	}
+}
+
+func TestDecodeReturnsEmptyForUnsupportedEncodingFormat(t *testing.T) {
+	decoded := Decode(encodingFormatMarkerPrefix + "\u200C" + encodeLegacy("Hello"))
+	if decoded != "" {
+		t.Fatalf("Decode() = %q, want empty string for unsupported encoding format", decoded)
+	}
+}
+
+func TestExtractRejectsUnsupportedEncodingFormat(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader(encodingFormatMarkerPrefix + "\u200C" + encodeLegacy("Hello")))
+	writer := bufio.NewWriter(io.Discard)
+	_, err := Extract(reader, writer)
+	if !errors.Is(err, ErrUnsupportedEncodingFormat) {
+		t.Fatalf("Extract() error = %v, want %v", err, ErrUnsupportedEncodingFormat)
+	}
+}
+
 func TestEncodeAndDecodeDoesNotUseMutableRuneCopies(t *testing.T) {
 	runes := invisibles.InvisibleRunes()
 	runes[0] = 'A'
@@ -109,8 +150,8 @@ func TestInvisibleRuneToCodeFailure(t *testing.T) {
 func TestEmbedRepeatEmbedsDifferentlyFromNoRepeat(t *testing.T) {
 	message := "Hi"
 	// Host text longer than what's needed to embed the message once.
-	// Encode("Hi") produces 8*ceil(2/3) = 8 invisible runes; host text of 200 chars
-	// ensures encoded runes would be exhausted well before the host ends.
+	// The host text is long enough that encoded runes are exhausted well before
+	// the host ends.
 	hostText := strings.Repeat("Hello World! ", 20)
 
 	embed := func(rep bool) string {
@@ -153,6 +194,9 @@ func TestEmbedRepeatExtractRecoversMessage(t *testing.T) {
 	// string will be message repeated; check that it starts with the original message.
 	if !strings.HasPrefix(decoded, message) {
 		t.Errorf("Extract after Embed(repeat=true): got %q, want prefix %q", decoded, message)
+	}
+	if strings.Contains(decoded, "invisible:encoding") {
+		t.Errorf("Extract after Embed(repeat=true) leaked encoding marker in decoded text: %q", decoded)
 	}
 }
 

--- a/invisibles/invisibles.go
+++ b/invisibles/invisibles.go
@@ -19,6 +19,10 @@ var invisibleRunes = [...]rune{
 	'\uFEFF', // ZERO WIDTH NO-BREAK SPACE
 }
 
+// EncodingFormatMarkerRune is reserved for encoding format markers. It is
+// extracted as invisible metadata, but is not part of the legacy data alphabet.
+const EncodingFormatMarkerRune = '\u200D' // ZERO WIDTH JOINER
+
 func InvisibleRunes() []rune {
 	return append([]rune(nil), invisibleRunes[:]...)
 }
@@ -45,7 +49,7 @@ func GetInvisibleRune() rune {
 }
 
 func IsGetInvisibleRune(r rune) bool {
-	return InvisibleRuneCode(r) >= 0
+	return r == EncodingFormatMarkerRune || InvisibleRuneCode(r) >= 0
 }
 
 func InvisibleRune(index int) (rune, bool) {

--- a/invisibles/invisibles_test.go
+++ b/invisibles/invisibles_test.go
@@ -21,6 +21,10 @@ func TestInvisibleRunesReturnsCopy(t *testing.T) {
 func TestIsGetInvisibleRune(t *testing.T) {
 	IsGetInvisibleRuneTester(t, 'x', false)
 	IsGetInvisibleRuneTester(t, '\u2060', true)
+	IsGetInvisibleRuneTester(t, EncodingFormatMarkerRune, true)
+	if InvisibleRuneCode(EncodingFormatMarkerRune) != -1 {
+		t.Errorf("%#U must be reserved for metadata, not mapped as data", EncodingFormatMarkerRune)
+	}
 }
 
 func IsGetInvisibleRuneTester(t *testing.T, testRune rune, shouldBe bool) {


### PR DESCRIPTION
## Summary
- Prefix newly encoded payloads with a reserved invisible v1 format marker.
- Keep markerless legacy payloads readable.
- Reject unsupported payloads that use the reserved marker prefix.

## Tests
- `gofmt -w embedding/embedding.go embedding/embedding_test.go invisibles/invisibles.go invisibles/invisibles_test.go`
- `go get -v -t -d ./... && git diff --exit-code -- go.mod go.sum`
- `go vet ./...`
- `typos`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `go install ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./embedding ./invisibles`
- `git diff --check`
