### PR TITLE
ci: pin goreleaser version and fix deprecated --rm-dist flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,15 @@ jobs:
 
       - name: setup
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26.0"
 
       - name: release
         if: startsWith(github.event.ref, 'refs/tags')
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+          version: v2.16.0
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix three CI reproducibility issues in `.github/workflows/release.yml`.

### Changes

- **Pin goreleaser version**: `version: latest` → `version: v2.16.0`  
  Using `latest` means the goreleaser CLI version changes silently with every
  release. If goreleaser ships a breaking change (e.g., major version bump),
  the release workflow breaks without any code change.

- **Fix deprecated flag**: `--rm-dist` → `--clean`  
  `--rm-dist` was renamed to `--clean` in goreleaser v2. Using the old flag
  with a future goreleaser version would cause the release to fail.

- **Pin Go version**: add `go-version: "1.26.0"` to `actions/setup-go`  
  Without an explicit version, setup-go picks the Go version from the runner's
  default, which may differ from the `1.26.0` used in `golang-test.yml`. Tests
  pass on 1.26.0 but the release binary could be built with a different version.

### What does not change

- The `goreleaser/goreleaser-action` SHA pin (`e435ccd7...`) is unchanged.
- No `.goreleaser.yaml` is added; the default configuration continues to apply.
