### PR TITLE
deps: update go directive from 1.19 to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/kitsuyui/invisible
 
-go 1.19
+go 1.26
 
 require github.com/google/subcommands v1.2.0


### PR DESCRIPTION
## Summary

`go.mod` declared `go 1.19` but CI (`golang-test.yml`) builds with `go-version: 1.26.0`,
creating a 7-version gap between the declared minimum requirement and the actual build environment.

Update the `go` directive to `1.26` to match the CI toolchain version.

## Changes

- `go.mod`: `go 1.19` → `go 1.26`

## Verification

- All tests pass (`go test ./...`)
- Lint clean (`go vet ./...`)