### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ $ invisible version
 
 Prints the installed version. Returns `(devel)` when built from source and `(unknown)` when build information is unavailable.
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and run the following command once after cloning:
+
+```console
+$ lefthook install
+```
+
+This sets up the following local Git hooks that mirror the CI checks:
+
+- **pre-commit**: runs `go vet ./...` to catch common issues before each commit.
+- **pre-push**: runs `go vet ./...` and `go test ./...` to verify correctness before pushing.
+
+CI still runs the full test suite on every pull request and push to `main` — the hooks only bring that feedback earlier, during local development.
+
 ## LICENSE
 
 ### Source

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+
+pre-push:
+  jobs:
+    - name: vet
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go vet ./...
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; go test ./...


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` with a `pre-commit` hook (`go vet ./...`) and a `pre-push` hook (`go vet ./...` + `go test ./...`), mirroring the `golang-test` CI checks.
- Add a `## Development` section to `README.md` documenting `lefthook install` and what each hook does.
- CI workflow is unchanged; the hooks only surface feedback earlier during local development.

## Changed files

- `lefthook.yml` — new file defining the pre-commit and pre-push hooks.
- `README.md` — new Development section inserted before the License section.
