### PR TITLE
feat(octocov): add coverage acceptable threshold at 60%

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage.out
+  acceptable: current >= 60%
 codeToTestRatio:
   code:
     - "**/*.go"


### PR DESCRIPTION
## Summary

Coverage is measured and displayed via octocov, but `.octocov.yml` had no `coverage.acceptable` threshold set. Without it, a coverage regression passes CI silently — octocov only comments on PRs but never fails them.

Add `acceptable: current >= 60%` under the `coverage:` block. This causes octocov to fail CI when total statement coverage drops below 60%.

## Context

Current total statement coverage is approximately 70%, giving a ~10 percentage-point buffer before CI would fail. The threshold is set conservatively to avoid immediately breaking CI while still catching significant regressions.

## Changed files

- `.octocov.yml` — add `acceptable: current >= 60%` under `coverage:`

## Verification

- `go test ./...` passes (all packages).
- `go vet ./...` clean.
- `gofmt -l .` clean.
- `staticcheck ./...`: 1 pre-existing ST1018 finding in `simplenoise/simplenoise_test.go` (intentional use of invisible Unicode in test data for this library; not introduced by this change).

## Trade-offs

60% is a conservative floor. It catches major regressions (>10pp drop) without requiring every new function to be covered. The threshold can be raised incrementally as test coverage improves.
