### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for security vulnerabilities.
+
+Use GitHub private vulnerability reporting:
+
+<https://github.com/kitsuyui/invisible/security/advisories/new>
+
+Include the following details when possible:
+
+- affected version or commit;
+- a short impact summary;
+- steps to reproduce or a minimal proof of concept;
+- whether hidden messages, generated text, terminal output, or input files can
+  be exposed, corrupted, or misdecoded.
+
+The maintainer will review the report as soon as possible. If the issue is
+confirmed, a fix and public advisory will be prepared after coordinated
+disclosure is appropriate.


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with private vulnerability reporting guidance.
- Ask reporters not to open public issues for security vulnerabilities.
- Document useful report details for this invisible-text tool.

## Verification

- `git diff --check`
- `go get -v -t -d ./...`
- `go vet ./...`
- `go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...`
- `typos SECURITY.md`

## Notes

- The reusable spellcheck workflow is not fully reproducible locally; `typos
  SECURITY.md` was run as a local spelling check.
