### PR TITLE
Run release tests before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           go-version: "1.26.0"
 
+      - name: install dependencies
+        run: go get -v -t -d ./...
+
+      - name: lint
+        run: go vet ./...
+
+      - name: test
+        run: go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
+
       - name: release
         if: startsWith(github.event.ref, 'refs/tags')
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6


### PR DESCRIPTION
Summary
- Add the same dependency install, vet, and race/coverage test gates used by the Go test workflow to the tag release workflow.
- Keep the pinned Go version and pinned action references in the release job.
- Run GoReleaser only after the pre-release checks pass.

Checks
- git diff --check
- typos .github/workflows/release.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- go get -v -t -d ./...
- go vet ./...
- go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
- go test ./...
- collateral check: clean
- foreground implement-validator: overall: pass

Notes
- The release workflow now mirrors the existing Go test workflow before invoking GoReleaser, so tag releases fail before publishing if the test gate fails.
