### PR TITLE
Add govulncheck CI workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,30 @@
+name: govulncheck
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
+          repo-checkout: false
+          go-package: ./...


### PR DESCRIPTION
## Summary

Add a dedicated `govulncheck.yml` workflow to scan Go module dependencies for known vulnerabilities on every PR and push to main.

Previously CI ran only `go vet` and `go test`, which do not detect known CVEs in dependencies. This adds supply-chain vulnerability detection using the official Go vulnerability scanner.

## Changes

- New: `.github/workflows/govulncheck.yml`
  - Runs `golang/govulncheck-action` on pull requests and pushes to `main`
  - Uses `go.mod` to determine the Go version
  - SHA-pinned action consistent with existing workflow conventions

## Verification

- `go vet ./...`: clean
- YAML syntax validated
- No collateral findings from pre-publication check

## Trade-offs

`govulncheck` reports vulnerabilities in the dependency graph that are reachable from actual call paths, keeping false positives low. If a future dependency update introduces a known CVE, this workflow will block the PR before merge.