### PR TITLE
fix: add context to CLI error messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -46,7 +47,7 @@ func (p *addNoise) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
 	if err := simplenoise.AddRandomNoise(p.frequency, p.maxSize, reader, writer); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		printCommandError("add-noise", "add random noise", err)
 		return subcommands.ExitFailure
 	}
 	return subcommands.ExitSuccess
@@ -79,7 +80,7 @@ func (p *encode) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	reader := bufio.NewReader(os.Stdin)
 	writer := bufio.NewWriter(os.Stdout)
 	if err := embedding.Embed(p.message, reader, writer, true); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		printCommandError("encode", "embed message", err)
 		return subcommands.ExitFailure
 	}
 	return subcommands.ExitSuccess
@@ -104,15 +105,15 @@ func (p *decode) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	writer := bufio.NewWriter(os.Stdout)
 	decoded, err := embedding.Extract(reader, bufio.NewWriter(io.Discard))
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		printCommandError("decode", "extract hidden message", err)
 		return subcommands.ExitFailure
 	}
 	if _, err := writer.WriteString(stripANSI(decoded)); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		printCommandError("decode", "write decoded message", err)
 		return subcommands.ExitFailure
 	}
 	if err := writer.Flush(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		printCommandError("decode", "flush decoded message", err)
 		return subcommands.ExitFailure
 	}
 	return subcommands.ExitSuccess
@@ -128,6 +129,13 @@ func (*versionCmd) Usage() string {
 `
 }
 func (*versionCmd) SetFlags(f *flag.FlagSet) {}
+
+func printCommandError(command string, stage string, err error) {
+	if err == nil {
+		err = errors.New("unknown error")
+	}
+	fmt.Fprintf(os.Stderr, "error: %s: %s: %v\n", command, stage, err)
+}
 
 func (*versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	info, ok := debug.ReadBuildInfo()

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"flag"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/subcommands"
@@ -38,4 +43,51 @@ func TestVersionCmdReturnsSuccess(t *testing.T) {
 	if status != subcommands.ExitSuccess {
 		t.Errorf("Execute() = %v, want ExitSuccess", status)
 	}
+}
+
+func TestPrintCommandErrorAddsCommandAndStage(t *testing.T) {
+	stderr := captureStderr(t, func() {
+		printCommandError("decode", "extract hidden message", errors.New("unexpected EOF"))
+	})
+
+	want := "error: decode: extract hidden message: unexpected EOF\n"
+	if stderr != want {
+		t.Errorf("stderr = %q, want %q", stderr, want)
+	}
+}
+
+func TestPrintCommandErrorHandlesNilError(t *testing.T) {
+	stderr := captureStderr(t, func() {
+		printCommandError("encode", "embed message", nil)
+	})
+
+	if !strings.Contains(stderr, "error: encode: embed message: unknown error") {
+		t.Errorf("stderr = %q, want command and stage context", stderr)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.Stderr = original
+		_ = reader.Close()
+	}()
+
+	os.Stderr = writer
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
 }


### PR DESCRIPTION
## Summary
- Add contextual CLI error output for `add-noise`, `encode`, and `decode`.
- Distinguish `decode` failures for extract, write, and flush steps.
- Add regression tests for the stderr formatter.

## Tests
- gofmt -w main.go main_test.go
- go test ./...
- go vet ./...
- go test -v -cover -race -covermode=atomic -coverprofile=coverage.out ./...
- collateral check: no violations or advisories
- GOBIN=/tmp/kimono-tools go install golang.org/x/vuln/cmd/govulncheck@latest && /tmp/kimono-tools/govulncheck ./... 
