### PR TITLE
test: cover DeNoiseAndWriteNoise noise writer output

### DIFF
--- a/simplenoise/simplenoise_test.go
+++ b/simplenoise/simplenoise_test.go
@@ -71,3 +71,31 @@ func TestDeNoiseReturnsWriterError(t *testing.T) {
 		t.Fatalf("DeNoise() error = %v, want %v", err, errSimpleNoiseWriter)
 	}
 }
+
+func TestDeNoiseAndWriteNoiseWritesExtractedNoise(t *testing.T) {
+	// Regression: the noiseWriter argument is the only path that exposes the
+	// invisible runes stripped out during DeNoise; DeNoise() itself discards
+	// them via io.Discard, so a test that only calls DeNoise cannot catch a
+	// regression here.
+	noisy := "H⁢el⁣lo" // H + INVISIBLE TIMES + el + INVISIBLE SEPARATOR + lo
+	plain := new(bytes.Buffer)
+	noise := new(bytes.Buffer)
+	if err := DeNoiseAndWriteNoise(strings.NewReader(noisy), plain, noise); err != nil {
+		t.Fatal(err)
+	}
+	if got := plain.String(); got != "Hello" {
+		t.Errorf("plain writer = %q, want %q", got, "Hello")
+	}
+	if got := noise.String(); got != "⁢⁣" {
+		t.Errorf("noise writer = %q, want %q", got, "⁢⁣")
+	}
+}
+
+func TestDeNoiseAndWriteNoiseReturnsNoiseWriterError(t *testing.T) {
+	noisy := "H⁢ello" // H + INVISIBLE TIMES + ello
+	plain := new(bytes.Buffer)
+	err := DeNoiseAndWriteNoise(strings.NewReader(noisy), plain, failingSimpleNoiseWriter{})
+	if !errors.Is(err, errSimpleNoiseWriter) {
+		t.Fatalf("DeNoiseAndWriteNoise() error = %v, want %v", err, errSimpleNoiseWriter)
+	}
+}


### PR DESCRIPTION
## Why

`simplenoise.DeNoiseAndWriteNoise`'s `noiseWriter` argument is the only path
that exposes the invisible runes stripped out during de-noising.
`DeNoise()` itself discards that output via `io.Discard`, and no existing
test called `DeNoiseAndWriteNoise` directly with a real writer, so a
regression in the `noiseWriter` write path would not be caught by
`simplenoise_test.go`.

The `.octocov.yml` `acceptable: current >= 60%` threshold does not close
this gap either, since the package's overall coverage already clears 60%
without exercising this path.

## What changed

Added two tests in `simplenoise/simplenoise_test.go`:

- `TestDeNoiseAndWriteNoiseWritesExtractedNoise`: calls
  `DeNoiseAndWriteNoise` directly and asserts both the plain-text writer and
  the noise writer receive the expected output.
- `TestDeNoiseAndWriteNoiseReturnsNoiseWriterError`: asserts a write error
  from the `noiseWriter` argument propagates from `DeNoiseAndWriteNoise`.

This is a test-only change; `simplenoise.go` is unmodified and no runtime
behavior changes.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...` — all packages pass
- `go test ./simplenoise/... -cover` — coverage increased to 84.6% of
  statements in the `simplenoise` package
