### PR TITLE
Fix unreachable version command registration

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,13 +147,18 @@ func (*versionCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{})
 	return subcommands.ExitSuccess
 }
 
+func registerCommands(register func(subcommands.Command, string)) {
+	register(subcommands.HelpCommand(), "")
+	register(subcommands.FlagsCommand(), "")
+	register(subcommands.CommandsCommand(), "")
+	register(&addNoise{}, "")
+	register(&encode{}, "")
+	register(&decode{}, "")
+	register(&versionCmd{}, "")
+}
+
 func main() {
-	subcommands.Register(subcommands.HelpCommand(), "")
-	subcommands.Register(subcommands.FlagsCommand(), "")
-	subcommands.Register(subcommands.CommandsCommand(), "")
-	subcommands.Register(&addNoise{}, "")
-	subcommands.Register(&encode{}, "")
-	subcommands.Register(&decode{}, "")
+	registerCommands(subcommands.Register)
 
 	flag.Parse()
 	ctx := context.Background()

--- a/main_test.go
+++ b/main_test.go
@@ -45,6 +45,18 @@ func TestVersionCmdReturnsSuccess(t *testing.T) {
 	}
 }
 
+func TestRegisterCommandsIncludesVersion(t *testing.T) {
+	var names []string
+
+	registerCommands(func(command subcommands.Command, _ string) {
+		names = append(names, command.Name())
+	})
+
+	if !containsCommand(names, "version") {
+		t.Fatalf("registered commands = %v, want version", names)
+	}
+}
+
 func TestPrintCommandErrorAddsCommandAndStage(t *testing.T) {
 	stderr := captureStderr(t, func() {
 		printCommandError("decode", "extract hidden message", errors.New("unexpected EOF"))
@@ -90,4 +102,13 @@ func captureStderr(t *testing.T, fn func()) string {
 		t.Fatal(err)
 	}
 	return buf.String()
+}
+
+func containsCommand(commands []string, target string) bool {
+	for _, command := range commands {
+		if command == target {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- register the existing `version` command in the CLI entrypoint so `invisible version` is reachable
- centralize command registration in one helper and assert that `version` is part of the registered command set
- keep the change scoped to the CLI wiring and its regression coverage

## Why
`README.md` documents `invisible version`, and `versionCmd` already exists, but `main()` did not register it. That left the documented command unreachable while the existing unit test still passed because it exercised the handler in isolation instead of the registration path.

## Verification
- `go build ./...`
- `go vet ./...`
- `go test ./...`
